### PR TITLE
Il sistema internazionale non indica i Byte, ma li referenzia solamente.

### DIFF
--- a/doc/doc_02_cap_01.rst
+++ b/doc/doc_02_cap_01.rst
@@ -270,7 +270,7 @@ Gli SLI calcolati devono includere la latenza aggiuntiva dovuta ad eventuali com
 
 Essi inoltre devono:
 
--   utilizzare unità di misura indicate o referenziate nel sistema internazionale (ad es., secondi, bytes);
+-   utilizzare unità di misura referenziate dal Sistema Internazionale (ad es., secondi, bytes);
 
 -   indicare nel nome identificativo l'eventuale periodo di aggregazione coi soli suffissi s (secondi), m (minuti), d (giorni) e y (anni) utilizzando al posto dei mesi il numero di giorni.
 

--- a/doc/doc_02_cap_01.rst
+++ b/doc/doc_02_cap_01.rst
@@ -270,7 +270,7 @@ Gli SLI calcolati devono includere la latenza aggiuntiva dovuta ad eventuali com
 
 Essi inoltre devono:
 
--   utilizzare unità di misura del sistema internazionale (ad es., secondi, bytes);
+-   utilizzare unità di misura indicate o referenziate nel sistema internazionale (ad es., secondi, bytes);
 
 -   indicare nel nome identificativo l'eventuale periodo di aggregazione coi soli suffissi s (secondi), m (minuti), d (giorni) e y (anni) utilizzando al posto dei mesi il numero di giorni.
 


### PR DESCRIPTION
## I expect

bytes to be identified in the SI

## Instead

they are just referenced from the SI from IEC https://www.bipm.org/utils/common/pdf/si_brochure_8.pdf