### PR TITLE
Fix #9: Reuse checks from https://github.com/italia/design-docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # python test files
 .tox
 *.py[co]
+
+# sphinx builds
+_*

--- a/conf.py
+++ b/conf.py
@@ -98,7 +98,7 @@ language = 'it'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['.*', 'README', 'README.md', 'LICENSE.md']
+exclude_patterns = ['.*', 'venv', 'README', 'README.md', 'LICENSE.md']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/conf.py
+++ b/conf.py
@@ -98,7 +98,7 @@ language = 'it'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['.DS_Store', 'README', 'README.md', '.venv*']
+exclude_patterns = ['.*', 'README', 'README.md', 'LICENSE.md']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -248,7 +248,7 @@ latex_logo = "media/agid-logo.png"
 latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-latex_show_urls = False
+latex_show_urls = 'footnote'
 
 # Documents to append as an appendix to all manuals.
 #latex_appendices = []

--- a/doc/doc_02_cap_01.rst
+++ b/doc/doc_02_cap_01.rst
@@ -248,7 +248,9 @@ L'integrazione può coinvolgere numerose organizzazioni e erogatori esterni di i
 
 Gli SLA possono essere statici o dinamici. Negli SLA dinamici, gli SLO (con associati SLI) variano nel tempo ed i periodi di validità definiscono gli intervalli di validità di questi ultimi (ad es., in orario lavorativo gli SLO possono essere differenti di quelli imposti durante la notte). La misurazione dei livelli di QoS all'interno di uno SLA richiedono il tracciamento delle operazioni effettuate in un contesto infrastrutturale multi-dominio (geografico, tecnologico e applicativo). In uno scenario tipico, ogni interfaccia di servizio può interagire con molteplici altre interfacce di servizio, cambiando il suo ruolo da erogatore a fruitore in alcune interazioni, ognuna governata da un differente SLA.
 
-Recentemente, gli SLA hanno iniziato ad includere non soltanto vincoli relativi all'erogatore, ma anche vincoli che impongono ai singoli fruitori delle interfacce di servizio dei limiti relativi al ritmo ed alla quantità delle richieste. A tal fine gli erogatori devono definire ed esporre ai fruitori politiche di throttling [10]_ (anche noto come rate limiting) segnalando eventuali limiti raggiunti. Gli erogatori dovrebbero far rispettare le quote anche se se il sistema non è in sovraccarico, incentivando i fruitori a rispettarle.
+Recentemente, gli SLA hanno iniziato ad includere non soltanto vincoli relativi all'erogatore, ma anche vincoli che impongono ai singoli fruitori delle interfacce di servizio dei limiti relativi al ritmo ed alla quantità delle richieste.
+A tal fine gli erogatori devono definire ed esporre ai fruitori politiche di throttling [10]_ (anche noto come rate limiting) segnalando eventuali limiti raggiunti.
+Gli erogatori dovrebbero far rispettare le quote anche se se il sistema non è in sovraccarico, incentivando i fruitori a rispettarle.
 
 Esempi di SLI sono i seguenti:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 git+https://github.com/italia/docs-italia-theme.git
 git+https://github.com/pdavide/sphinxcontrib-discourse
+git+https://github.com/pdavide/sphinxcontrib-versiontag
 doc8
+sphinx
+recommonmark

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,10 @@ skipsdist = True
 
 [testenv]
 deps = -rrequirements.txt
-commands = doc8  --ignore D001,D002,D003,D004 doc 
-
+whitelist_externals =
+  mkdir
+commands =
+  mkdir -p _static
+  doc8  --ignore D001,D002,D003,D004 doc
+  sphinx-build -n -W -T -b html . _build/html
 


### PR DESCRIPTION
## This PR

 - integrates sanity checks from https://github.com/italia/design-docs/
 
## How does it work

  - add the following command to the test environment (in circleci)

     `sphinx-build -n -W -T -b html . _build/html` 

  - skips LICENSE.md and .tox

  - show urls in footnotes (eg. for printing)