### PR TITLE
Fix: #9. Integrate checks from docsitalia.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,4 +12,4 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install tox
-            tox
+            tox -e build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 # python test files
 .tox
 *.py[co]
+
+# ide
+.idea
+
+# sphinx builds
+_*

--- a/conf.py
+++ b/conf.py
@@ -99,7 +99,7 @@ language = 'it'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['.DS_Store', 'README', 'README.md', '.venv*']
+exclude_patterns = ['.DS_Store', 'README', 'README.md', 'LICENSE.md', '.venv*', '.tox', '*.md']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -133,7 +133,7 @@ html_theme_options = {
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
-    html_theme = 'docs-italia-theme'
+    html_theme = 'docs_italia_theme'
     #html_theme_path = ["themes", ]
 else:
     # Override default css to get a larger width for ReadTheDoc build
@@ -164,7 +164,7 @@ else:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 git+https://github.com/italia/docs-italia-theme.git
 git+https://github.com/pdavide/sphinxcontrib-discourse
+git+https://github.com/pdavide/sphinxcontrib-versiontag
+recommonmark
 doc8
+sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,20 @@ skipsdist = True
 
 [testenv]
 deps = -rrequirements.txt
-commands = doc8  --ignore D001,D002,D003,D004 doc 
+commands =
+  doc8  --ignore D001,D002,D003,D004 doc
+
+[testenv:build]
+commands =
+  doc8  --ignore D001,D002,D003,D004 doc
+  sphinx-build -b html . _build/
+
+# Replace special characters in docs.
+[testenv:refactor]
+deps = 
+whitelist_externals =
+  find
+commands = 
+  find doc -name *.rst -exec  sed -i 's/[“”]/"/g; s/’/\d39/g'  \{\} ;
 
 


### PR DESCRIPTION
## This PR

- integrates sanity checks for docs;
- allows using `tox -e refactor` to replace non-ascii quoting chars in docs;
- fixes local build with latest docsitalia theme