### PR TITLE
Fix indentation and responses in examples.

### DIFF
--- a/doc/media/rest-blocking.yaml
+++ b/doc/media/rest-blocking.yaml
@@ -45,8 +45,10 @@ paths:
            application/json:
              schema:
                $ref: '#/components/schemas/ErrorMessage'
-       500:
-         description: Errore interno
+       default:
+         description: |-
+           Errore inatteso. Non ritornare informazioni
+           sulla logica interna e/o non pertinenti all'interfaccia.
          content:
            application/json:
              schema:

--- a/doc/media/rest-callback-client.yaml
+++ b/doc/media/rest-callback-client.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
- info:
-   title: RESTCallbackClient
+info:
+ title: RESTCallbackClient
  version: "1.0"
  description: |-
    Questo file descrive semplicemente i metodi di un'API
@@ -9,51 +9,54 @@ openapi: 3.0.1
  license:
    name: Apache 2.0 License
    url: http://www.apache.org/licenses/LICENSE-2.0.html
- paths:
-   /MResponse:
-     post:
-       description: M
-       operationId: PushResponseMessage
-       parameters:
-       - name: X-Correlation-ID
-         in: header
-         schema:
-           type: string
-       requestBody:
+paths:
+ /MResponse:
+   post:
+     description: M
+     operationId: PushResponseMessage
+     parameters:
+     - name: X-Correlation-ID
+       in: header
+       schema:
+         type: string
+     requestBody:
+       content:
+         application/json:
+           schema:
+             $ref: '#/components/schemas/MResponseType'
+     responses:
+       200:
+         description: Risposta correttamente ricevuta
          content:
            application/json:
              schema:
-               $ref: '#/components/schemas/MResponseType'
-       responses:
-         500:
-           description: Errore interno avvenuto
-           content:
-             application/json:
-               schema:
-                 $ref: '#/components/schemas/ErrorMessage'
-         404:
-           description: Identificativo non trovato
-           content:
-             application/json:
-               schema:
-                 $ref: '#/components/schemas/ErrorMessage'
-         200:
-           description: Risposta correttamente ricevuta
-           content:
-             application/json:
-               schema:
-                 $ref: '#/components/schemas/ACKMessage'
- components:
-   schemas:
-     ACKMessage:
-       type: object
-       properties:
-         outcome:
-           type: string
-     MResponseType:
-       type: object
-       properties:
-         c:
-           type: string
-     ErrorMessage:
-       $ref: 'https://raw.githubusercontent.com/teamdigitale/openapi/0.0.4/docs/definitions.yaml#/schemas/Problem'
+               $ref: '#/components/schemas/ACKMessage'
+       404:
+         description: Identificativo non trovato
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/ErrorMessage'
+       default:
+         description: |-
+           Errore inatteso. Non ritornare informazioni
+           sulla logica interna e/o non pertinenti all'interfaccia.
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/ErrorMessage'
+
+components:
+ schemas:
+   ACKMessage:
+     type: object
+     properties:
+       outcome:
+         type: string
+   MResponseType:
+     type: object
+     properties:
+       c:
+         type: string
+   ErrorMessage:
+     $ref: 'https://raw.githubusercontent.com/teamdigitale/openapi/0.0.4/docs/definitions.yaml#/schemas/Problem'

--- a/doc/media/rest-callback-server.yaml
+++ b/doc/media/rest-callback-server.yaml
@@ -43,17 +43,9 @@ paths:
              schema:
                $ref: '#/components/schemas/ACKMessage'
        404:
-         description: Identificativo non trovato
-         content:
-           application/json:
-             schema:
-               $ref: '#/components/schemas/ErrorMessage'
-       500:
-         description: Errore interno avvenuto
-         content:
-           application/json:
-             schema:
-               $ref: '#/components/schemas/ErrorMessage'
+         $ref: '#/components/responses/404NotFound'
+       default:
+         $ref: '#/components/responses/default'
      callbacks:
        completionCallback:
          '{$request.header#/X-ReplyTo}':
@@ -71,18 +63,21 @@ paths:
                      schema:
                        $ref: '#/components/schemas/ACKMessage'
                404:
-                 description: Identificativo non trovato
-                 content:
-                   application/json:
-                     schema:
-                       $ref: '#/components/schemas/ErrorMessage'
-               500:
-                 description: Errore interno avvenuto
-                 content:
-                   application/json:
-                     schema:
-                       $ref: '#/components/schemas/ErrorMessage'
+                 $ref: '#/components/responses/404NotFound'
+               default:
+                 $ref: '#/components/responses/default'
 components:
+ responses:
+   404NotFound:
+     $ref: 'https://teamdigitale.github.io/openapi/definitions.yaml#/responses/404NotFound'
+   default:
+     description: |-
+       Errore inatteso. Non ritornare informazioni
+       sulla logica interna e/o non pertinenti all'interfaccia.
+     content:
+       application/json:
+         schema:
+           $ref: '#/components/schemas/ErrorMessage'
  schemas:
    MType:
      type: object


### PR DESCRIPTION
## This PR

validates yaml
validates OAS3
uses `default` on errors outstide contracts

## We should

add an oas validator in the CI