### PR TITLE
Non usare gli stessi certificati per TLS e app

### DIFF
--- a/doc/doc_04/soluzioni-di-sicurezza.rst
+++ b/doc/doc_04/soluzioni-di-sicurezza.rst
@@ -103,12 +103,6 @@ Questa soluzione utilizza i seguenti profili:
 Precondizioni
 ^^^^^^^^^^^^^
 
-Si assume che il certificato che garantisce l’integrità del messaggio e
-l’autenticazione del Fruitore è lo stesso.
-
-Si assume che il certificato che garantisce l’integrità del messaggio di
-conferma e l’autenticazione dell’Erogatore è lo stesso.
-
 Si assume l’esistenza di un trust tra fruitore ed erogatore che
 stabilisce:
 


### PR DESCRIPTION
## Questa PR

Rimuove due frasi ambigue.

Potrebbero suggerire di usare gli stessi cert per TLS e firma applicativa.
Se non vogliamo esplicitarlo basta rimuoverle.

Come detto più in basso, i certificati identificano fruitore ed erogatore: che siano lo stesso o siano differenti, non cambia.

Riferimento veloce:

 -  https://security.stackexchange.com/questions/97248/why-not-use-same-certificate-for-webserver-tls-and-signing-in-saml