### PR TITLE
Support single-html builds without sidebar.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -137,6 +137,12 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if not on_rtd:  # only import and set the theme if we're building docs locally
     html_theme = 'docs_italia_theme'
     #html_theme_path = ["themes", ]
+
+    # local builds with singlehtml don't need sidebar
+    # nor docs_italia_theme
+    if 'singlehtml' in sys.argv:
+        html_theme = 'basic'
+        html_theme_options.update({'no_sidebar': True})
 else:
     # Override default css to get a larger width for ReadTheDoc build
     html_context = {

--- a/tox.ini
+++ b/tox.ini
@@ -9,16 +9,21 @@ deps =
 commands =
   doc8  --ignore D001,D002,D003,D004 doc
 
+[testenv:py36-build]
+commands =
+  doc8  --ignore D001,D002,D003,D004 doc
+  sphinx-build -b html . _build/
+
+
 [testenv:build]
 commands =
   doc8  --ignore D001,D002,D003,D004 doc
   sphinx-build -b html . _build/
 
-
-[testenv:py27-build]
+[testenv:build-single]
 commands =
   doc8  --ignore D001,D002,D003,D004 doc
-  sphinx-build -b html . _build/
+  sphinx-build -b singlehtml . _build_single/
 
 # Replace special characters in docs.
 [testenv:refactor]


### PR DESCRIPTION
## This PR

adds ```tox -e single-html``` to build a single html file.