### PR TITLE
preliminary work on PATCH #110

### DIFF
--- a/doc/media/rest-crud.yaml
+++ b/doc/media/rest-crud.yaml
@@ -132,7 +132,7 @@ paths:
           format: int32
       requestBody:
         content:
-          application/json:
+          application/merge-patch+json:
             schema:
               $ref: '#/components/schemas/PatchPrenotazione'
       responses:

--- a/doc/profili-di-interazione/accesso-crud-a-risorse.rst
+++ b/doc/profili-di-interazione/accesso-crud-a-risorse.rst
@@ -178,7 +178,7 @@ Di seguito un esempio di chiamata per creare una prenotazione.
 .. code-block:: http
    :caption: Request
 
-   POST /appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni HTTP/1.1
+   POST /rest/appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni HTTP/1.1
 
    {
      "nome_proprio": "Mario",
@@ -216,7 +216,7 @@ nell\' :httpheader:`Location` al passo precedente.
 .. code-block:: http
    :caption: Request
 
-   GET /appuntamenti/rest/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
+   GET /rest/appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
 
 
 .. code-block:: http

--- a/doc/profili-di-interazione/accesso-crud-a-risorse.rst
+++ b/doc/profili-di-interazione/accesso-crud-a-risorse.rst
@@ -167,7 +167,7 @@ specifica seguente i metodi implementati sono :httpmethod:`POST` (creazione), DE
 (eliminazione), :httpmethod:`PATCH` (modifica) e :httpmethod:`GET` (lettura).
 
 
- Specifica Servizio Server  https://api.amministrazioneesempio.it/appuntamenti/v1/openapi.yaml
+ Specifica Servizio Server  https://api.amministrazioneesempio.it/rest/appuntamenti/v1/openapi.yaml
 
  .. literalinclude:: ../media/rest-crud.yaml
     :language: yaml
@@ -195,7 +195,7 @@ Di seguito un esempio di chiamata per creare una prenotazione.
    :caption: Response
 
    HTTP/1.1 201 Created
-   Location: https://api.amministrazioneesempio.it/appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254
+   Location: https://api.amministrazioneesempio.it/rest/appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254
 
    {
      "id": 12323254,
@@ -216,7 +216,7 @@ nell\' :httpheader:`Location` al passo precedente.
 .. code-block:: http
    :caption: Request
 
-   GET /appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
+   GET /appuntamenti/rest/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
 
 
 .. code-block:: http
@@ -244,7 +244,7 @@ Di seguito una richiesta di modifica dei dettagli di una prenotazione.
    :caption: Request
 
 
-   PATCH /appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
+   PATCH /rest/appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
    Content-Type: application/merge-patch+json
 
    {
@@ -281,7 +281,7 @@ il media-type suggerito dalla specifica tramite :httpheader:`Accept-Patch`
    :caption: Request
 
 
-   PATCH /appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
+   PATCH /rest/appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
    Content-Type: application/json
 
    {
@@ -304,7 +304,7 @@ Di seguito un esempio di cancellazione di una specifica prenotazione.
 .. code-block:: http
    :caption: Request
 
-   DELETE /appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
+   DELETE /rest/appuntamenti/v1/municipio/{id_municipio}/ufficio/{id_ufficio}/prenotazioni/12323254  HTTP/1.1
 
 
 .. code-block:: http


### PR DESCRIPTION
In generale lo schema delle URL degli endpoint prevede la specifica della versione e della tecnologia (rest/soap) propongo di sostituire:
- https://api.amministrazioneesempio.it/appuntamenti/v1
con  
- https://api.amministrazioneesempio.it/rest/v1/appuntamenti


