### PR TITLE
Fix: typo in data type

### DIFF
--- a/doc/profili-di-interazione/regole-comuni-rest-soap.rst
+++ b/doc/profili-di-interazione/regole-comuni-rest-soap.rst
@@ -27,7 +27,7 @@ Cioè:
 
 .. code-block:: JSON
 
-    { "given_name": "Paolo", "last_name": "Rossi", "id": 313 }
+    { "given_name": "Paolo", "family_name": "Rossi", "id": 313 }
 
 -  il payload di una response contenente più entry ​ritorna un oggetto
    contenente una lista​ e non direttamente una lista.


### PR DESCRIPTION
## This PR

Fixes a typo: schema is different from response.