### PR TITLE
use jpg directly

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+version: 2
+
+python:
+   version: 3.7
+build:
+  image: latest
+

--- a/conf.py
+++ b/conf.py
@@ -333,3 +333,4 @@ texinfo_documents = [
 numfig = True
 
 mermaid_cmd = "./mmdc.py"
+mermaid_output_format = "jpg"

--- a/mmdc.py
+++ b/mmdc.py
@@ -6,12 +6,15 @@ import json
 from requests import get
 from tempfile import NamedTemporaryFile
 from subprocess import check_output
+import logging
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger()
 
 
 def jpg_to_pdf(jpg_data, dpath):
     with NamedTemporaryFile() as fh:
         fh.write(jpg_data)
-        check_output(["./magick", "convert", fh.name, dpath])
+        check_output(["convert", fh.name, dpath])
 
 
 def get_mermaid_jpg(mermaid_txt):
@@ -34,6 +37,11 @@ if __name__ == "__main__":
     # Rely on mermaid website for renderings.
     mermaid_jpg = get_mermaid_jpg(mermaid_txt)
 
-    # Latex expects a pdf image.
-    jpg_to_pdf(mermaid_jpg, args.dpath)
+    if args.dpath.endswith("pdf"):
+        jpg_to_pdf(mermaid_jpg, args.dpath)
+    elif args.dpath.endswith("jpg"):
+        Path(args.dpath).write_bytes(mermaid_jpg)
+    else:
+        raise NotImplementedError("Format not supported. %r" % args.dpath)
+
     exit(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ doc8
 sphinx<=1.7
 
 # Render mermaid diagrams
-sphinxcontrib-mermaid==0.5.0
+git+https://github.com/teamdigitale/sphinxcontrib-mermaid@docsitalia-0.5
 requests
 


### PR DESCRIPTION
## This PR

Embed jpgs into doc without converting them to pdf

## It's done

- adding jpg support in sphinx-mermaid on `teamdigitale`'s fork (to be backported)
- improving mmdc.