### PR TITLE
Fix: #130. Usa .example per evitare di richiamare domini esistenti.

### DIFF
--- a/doc/01_Pattern interazione/06_pattern-non-bloccanti/01_nonblock_push/01_nonblock_push_rest.rst
+++ b/doc/01_Pattern interazione/06_pattern-non-bloccanti/01_nonblock_push/01_nonblock_push_rest.rst
@@ -88,7 +88,7 @@ https://api.ente.example/rest/nome-api/v1/RESTCallbackServer.yaml
 
 Specifica Servizio Client
 
-https://api.indirizzoclient.it/rest/nome-api/v1/RESTCallbackClient.yaml
+https://api.client.example/rest/nome-api/v1/RESTCallbackClient.yaml
 
 .. literalinclude:: RESTCallbackClient.yaml
    :language: yaml
@@ -108,7 +108,7 @@ Endpoint: https://api.ente.example/rest/nome-api/v1/resources/1234/M
    POST /rest/nome-api/v1/resources/1234/M HTTP/1.1
    Host: api.ente.example
    Content-Type: application/json
-   X-ReplyTo: https://api.indirizzoclient.it/rest/v1/nomeinterfacciaclient/Mresponse
+   X-ReplyTo: https://api.client.example/rest/v1/nomeinterfacciaclient/Mresponse
 
    {
      "a": {
@@ -137,14 +137,14 @@ della notifica.
 
 Endpoint
 
-https://api.indirizzoclient.it/rest/v1/nomeinterfacciaclient/Mresponse
+https://api.client.example/rest/v1/nomeinterfacciaclient/Mresponse
 
 3. Request
 
 .. code-block:: http
 
    POST /rest/v1/nomeinterfacciaclient/Mresponse HTTP/1.1
-   Host: api.indirizzoclient.it
+   Host: api.client.example
    Content-Type: application/json
    X-Correlation-ID: 69a445fb-6a9f-44fe-b1c3-59c0f7fb568d
 

--- a/doc/01_Pattern interazione/06_pattern-non-bloccanti/01_nonblock_push/02_nonblock_push_soap.rst
+++ b/doc/01_Pattern interazione/06_pattern-non-bloccanti/01_nonblock_push/02_nonblock_push_soap.rst
@@ -80,7 +80,7 @@ https://api.ente.example/soap/nome-api/v1?wsdl
 
 Specifica Servizio Fruitore (callback)
 
-https://api.indirizzoclient.it/soap/nome-api/v1?wsdl
+https://api.client.example/soap/nome-api/v1?wsdl
 
 .. literalinclude:: NONBLOCK_PUSH_SOAP_example_wsdl_fruitore.xml
    :language: xml
@@ -109,7 +109,7 @@ fruitore.
 
 Endpoint
 
-https://api.indirizzoclient.it/soap/nomeinterfacciaclient/v1Method
+https://api.client.example/soap/nomeinterfacciaclient/v1Method
 
 MRequestResponse
 

--- a/doc/01_Pattern interazione/06_pattern-non-bloccanti/01_nonblock_push/NONBLOCK_PUSH_SOAP_example_request_to_erogatore.xml
+++ b/doc/01_Pattern interazione/06_pattern-non-bloccanti/01_nonblock_push/NONBLOCK_PUSH_SOAP_example_request_to_erogatore.xml
@@ -1,7 +1,7 @@
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
     xmlns:m="http://ente.example/nome-api">
     <soap:Header>
-        <m:X-ReplyTo>https://api.indirizzoclient.it/soap/nome-api/v1</m:X-ReplyTo>
+        <m:X-ReplyTo>https://api.client.example/soap/nome-api/v1</m:X-ReplyTo>
     </soap:Header>
     <soap:Body>
         <m:MRequest>

--- a/doc/01_Pattern interazione/06_pattern-non-bloccanti/01_nonblock_push/NONBLOCK_PUSH_SOAP_example_wsdl_fruitore.xml
+++ b/doc/01_Pattern interazione/06_pattern-non-bloccanti/01_nonblock_push/NONBLOCK_PUSH_SOAP_example_wsdl_fruitore.xml
@@ -72,7 +72,7 @@
     
     <wsdl:service name="SOAPCallbackClientService">
         <wsdl:port binding="tns:SOAPCallbackClientServiceSoapBinding" name="SOAPCallbackClientPort">
-            <soap:address location="https://api.indirizzoclient.it/soap/nome-api/v1"/>
+            <soap:address location="https://api.client.example/soap/nome-api/v1"/>
         </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>

--- a/doc/02_Pattern sicurezza/05_accesso-del-fruitore/03_id_auth_rest_01.rst
+++ b/doc/02_Pattern sicurezza/05_accesso-del-fruitore/03_id_auth_rest_01.rst
@@ -131,7 +131,7 @@ Esempio porzione messaggio HTTP.
 
 .. code-block:: http
 
-   GET https://api.erogatore.org/rest/service/v1/hello/echo/Ciao HTTP/1.1
+   GET https://api.erogatore.example/rest/service/v1/hello/echo/Ciao HTTP/1.1
    Accept: application/json
    Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5c.vz8...
 
@@ -154,7 +154,7 @@ Esempio porzione JWT
    "iat": 1554382877,
    "nbf": 1554382877,
    "exp": 1554382879,
-   "aud": "https://api.erogatore.org/rest/service/v1/hello/echo"
+   "aud": "https://api.erogatore.example/rest/service/v1/hello/echo"
    }
 
 Gli elementi presenti nel tracciato rispettano le seguenti scelte

--- a/doc/02_Pattern sicurezza/05_accesso-del-fruitore/04_id_auth_rest_02.rst
+++ b/doc/02_Pattern sicurezza/05_accesso-del-fruitore/04_id_auth_rest_02.rst
@@ -140,7 +140,7 @@ Esempio porzione pacchetto HTTP.
 
 .. code-block:: http
 
-   GET https://api.erogatore.org/rest/service/v1/hello/echo/Ciao HTTP/1.1
+   GET https://api.erogatore.example/rest/service/v1/hello/echo/Ciao HTTP/1.1
    Accept: application/json
    Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5c.vz8...
 
@@ -159,7 +159,7 @@ Esempio porzione JWT
    
    # *payload*
    {
-	   "aud": "https://api.erogatore.org/rest/service/v1/hello/echo"
+	   "aud": "https://api.erogatore.example/rest/service/v1/hello/echo"
 	   "iat": 1516239022,
 	   "nbf": 1516239022,
 	   "exp": 1516239024,

--- a/doc/02_Pattern sicurezza/05_accesso-del-fruitore/media/ID_AUTH_SOAP_01_example_request.xml
+++ b/doc/02_Pattern sicurezza/05_accesso-del-fruitore/media/ID_AUTH_SOAP_01_example_request.xml
@@ -45,7 +45,7 @@
     <Action xmlns="http://www.w3.org/2005/08/addressing">http://profile.security.modi.agid.org/HelloWorld/sayHi</Action>
     <MessageID xmlns="http://www.w3.org/2005/08/addressing">urn:uuid:55e6bc57-2286-4b7d-82a9-fdbcf57721b1</MessageID>
     <To xmlns="http://www.w3.org/2005/08/addressing"
-      xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-96f9b013-17e5-489d-8068-52c3f1345c75">https://api.amministrazioneesempio.it/soap/echo/v1</To>
+      xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="id-96f9b013-17e5-489d-8068-52c3f1345c75">https://api.ente.example/soap/echo/v1</To>
     <ReplyTo xmlns="http://www.w3.org/2005/08/addressing">
       <Address>http://www.w3.org/2005/08/addressing/anonymous</Address>
     </ReplyTo>

--- a/doc/02_Pattern sicurezza/06_integrita/02_integrity_rest.rst
+++ b/doc/02_Pattern sicurezza/06_integrita/02_integrity_rest.rst
@@ -168,7 +168,7 @@ Richiesta HTTP con Digest e representation metadata
 
 .. code-block:: http
 
-   POST https://api.erogatore.org/rest/service/v1/hello/echo/ HTTP/1.1
+   POST https://api.erogatore.example/rest/service/v1/hello/echo/ HTTP/1.1
    Accept: application/json
    Agid-JWT-Signature: eyJhbGciOiJSUzI1NiIsInR5c.vz8...
    Digest: SHA-256=cFfTOCesrWTLVzxn8fmHl4AcrUs40Lv5D275FmAZ96E=
@@ -191,7 +191,7 @@ Porzione JWS con campi protetti dalla firma
    # *payload*
    
    {
-     "aud": "https://api.erogatore.org/rest/service/v1/hello/echo"
+     "aud": "https://api.erogatore.example/rest/service/v1/hello/echo"
      "iat": 1516239022,
      "nbf": 1516239022,
      "exp": 1516239024,

--- a/doc/media/soap-blocking.wsdl
+++ b/doc/media/soap-blocking.wsdl
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions  
 	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
-	xmlns:tns="http://amministrazioneesempio.it/nomeinterfacciaservizio" 
+	xmlns:tns="http://ente.example/nomeinterfacciaservizio" 
 	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" 
 	name="SOAPBlockingImplService" 
-	targetNamespace="http://amministrazioneesempio.it/nomeinterfacciaservizio">
+	targetNamespace="http://ente.example/nomeinterfacciaservizio">
 	<wsdl:types>
 		<xs:schema 
 			xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-			xmlns:tns="http://amministrazioneesempio.it/nomeinterfacciaservizio" 
+			xmlns:tns="http://ente.example/nomeinterfacciaservizio" 
 			attributeFormDefault="unqualified" elementFormDefault="unqualified" 
-			targetNamespace="http://amministrazioneesempio.it/nomeinterfacciaservizio">
+			targetNamespace="http://ente.example/nomeinterfacciaservizio">
 			<xs:element name="MRequest" type="tns:MRequest"/>
 			<xs:element name="MRequestResponse" type="tns:MRequestResponse"/>
 			<xs:complexType name="MRequest">
@@ -87,7 +87,7 @@
 	</wsdl:binding>
 	<wsdl:service name="SOAPBlockingImplService">
 		<wsdl:port binding="tns:SOAPBlockingImplServiceSoapBinding" name="SOAPBlockingImplPort">
-			<soap:address location="https://api.amministrazioneesempio.it/soap/nomeinterfacciaservizio/v1"/>
+			<soap:address location="https://api.ente.example/soap/nomeinterfacciaservizio/v1"/>
 		</wsdl:port>
 	</wsdl:service>
 </wsdl:definitions>

--- a/doc/media/soap-callback-client.wsdl
+++ b/doc/media/soap-callback-client.wsdl
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions 
 	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
-	xmlns:tns="http://amministrazioneesempio.it/nomeinterfacciaservizio" 
+	xmlns:tns="http://ente.example/nomeinterfacciaservizio" 
 	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" 
 	name="SOAPCallbackClientInterfaceService" 
-	targetNamespace="http://amministrazioneesempio.it/nomeinterfacciaservizio">
+	targetNamespace="http://ente.example/nomeinterfacciaservizio">
 	<wsdl:types>
 		<xs:schema 
 			xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-			xmlns:tns="http://amministrazioneesempio.it/nomeinterfacciaservizio" 
+			xmlns:tns="http://ente.example/nomeinterfacciaservizio" 
 			attributeFormDefault="unqualified" elementFormDefault="unqualified" 
-			targetNamespace="http://amministrazioneesempio.it/nomeinterfacciaservizio">
+			targetNamespace="http://ente.example/nomeinterfacciaservizio">
 			
 			<xs:element name="MRequestResponse" type="tns:MRequestResponse"/>
 			<xs:element name="MRequestResponseResponse" type="tns:MRequestResponseResponse"/>
@@ -74,7 +74,7 @@
 	</wsdl:binding>
 	<wsdl:service name="SOAPCallbackClientService">
 		<wsdl:port binding="tns:SOAPCallbackClientServiceSoapBinding" name="SOAPCallbackClientPort">
-			<soap:address location="https://api.indirizzoclient.it/soap/nomeinterfacciaservizio/v1"/>
+			<soap:address location="https://api.client.example/soap/nomeinterfacciaservizio/v1"/>
 		</wsdl:port>
 	</wsdl:service>
 </wsdl:definitions>

--- a/doc/media/soap-callback-server.wsdl
+++ b/doc/media/soap-callback-server.wsdl
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <wsdl:definitions  
 	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
-	xmlns:tns="http://amministrazioneesempio.it/nomeinterfacciaservizio" 
+	xmlns:tns="http://ente.example/nomeinterfacciaservizio" 
 	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/"  
 	name="SOAPCallbackServerService" 
-	targetNamespace="http://amministrazioneesempio.it/nomeinterfacciaservizio">
+	targetNamespace="http://ente.example/nomeinterfacciaservizio">
 	<wsdl:types>
 		<xs:schema 
 			xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-			xmlns:tns="http://amministrazioneesempio.it/nomeinterfacciaservizio" 
+			xmlns:tns="http://ente.example/nomeinterfacciaservizio" 
 			attributeFormDefault="unqualified" elementFormDefault="unqualified" 
-			targetNamespace="http://amministrazioneesempio.it/nomeinterfacciaservizio">
+			targetNamespace="http://ente.example/nomeinterfacciaservizio">
 			
 			<xs:element name="MRequest" type="tns:MRequest"/>
 			<xs:element name="MRequestResponse" type="tns:MRequestResponse"/>
@@ -104,7 +104,7 @@
 	
 	<wsdl:service name="SOAPCallbackService">
 		<wsdl:port name="SOAPCallbackPort" binding="tns:SOAPCallbackServiceSoapBinding" >
-			<soap:address location="https://api.amministrazioneesempio.it/soap/nomeinterfacciaservizio/v1"/>
+			<soap:address location="https://api.ente.example/soap/nomeinterfacciaservizio/v1"/>
 		</wsdl:port>
 	</wsdl:service>
 	

--- a/doc/media/soap-nonblocking.wsdl
+++ b/doc/media/soap-nonblocking.wsdl
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <wsdl:definitions
 	xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
-	xmlns:tns="http://amministrazioneesempio.it/nomeinterfacciaservizio"
+	xmlns:tns="http://ente.example/nomeinterfacciaservizio"
 	xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap12/" 
 	name="SOAPPullService"
-	targetNamespace="http://amministrazioneesempio.it/nomeinterfacciaservizio">
+	targetNamespace="http://ente.example/nomeinterfacciaservizio">
 	<wsdl:types>
 		<xs:schema 
 			xmlns:xs="http://www.w3.org/2001/XMLSchema"
-			xmlns:tns="http://amministrazioneesempio.it/nomeinterfacciaservizio"
+			xmlns:tns="http://ente.example/nomeinterfacciaservizio"
 			attributeFormDefault="unqualified" elementFormDefault="unqualified"
-			targetNamespace="http://amministrazioneesempio.it/nomeinterfacciaservizio">
+			targetNamespace="http://ente.example/nomeinterfacciaservizio">
 			
 			<xs:element name="MProcessingStatus" type="tns:MProcessingStatus" />
 			<xs:element name="MProcessingStatusResponse" type="tns:MProcessingStatusResponse" />
@@ -201,7 +201,7 @@
 	
 	<wsdl:service name="SOAPPullService">
 		<wsdl:port binding="tns:SOAPPullServiceSoapBinding" name="SOAPPullPort">
-			<soap:address location="https://api.amministrazioneesempio.it/soap/nomeinterfacciaservizio/v1" />
+			<soap:address location="https://api.ente.example/soap/nomeinterfacciaservizio/v1" />
 		</wsdl:port>
 	</wsdl:service>
 </wsdl:definitions>


### PR DESCRIPTION
## Questa PR

- usa `.example` per evitare di richiamare domini esistenti oggi o in futuro.