### PR TITLE
Typo Robustezza e' inclusa in raccomandazioni-generali.

### DIFF
--- a/doc/04_Raccomandazioni di implementazione/index.rst
+++ b/doc/04_Raccomandazioni di implementazione/index.rst
@@ -12,4 +12,3 @@ Documento operativo - Raccomandazioni di implementazione
   05_raccomandazioni-tecniche-per-rest.rst
   06_raccomandazioni-tecniche-per-soap.rst
   07_gestione-degli-allegati.rst
-  08_robustezza.rst


### PR DESCRIPTION
## Questa PR

- rimuove la definizione duplicata di `robustezza`, che è già inclusa in raccomandazioni generali